### PR TITLE
Prose-invert with tailwindcss/typography plugin for dark mode rendring

### DIFF
--- a/pages/blog/[...slug].vue
+++ b/pages/blog/[...slug].vue
@@ -10,7 +10,7 @@ const { data } = await useAsyncData(`content-${path}`, () => {
 
 <template>
     <!-- <p>{{ $route.params.slug }}</p> -->
-    <ContentRenderer :value="data" class="prose my-10 mx-auto max-w-7xl" />
+    <ContentRenderer :value="data" class="prose dark:prose-invert my-10 mx-auto max-w-7xl" />
     <div class="my-8">
         <a v-for="tag in  data.tags " :key="tag" :href="`/blog/tags/${tag}`"
         class="text-sm font-semibold inline-block py-2 px-4 rounded-lg text-gray-100 bg-blue-500 uppercase last:mr-0 mr-4">


### PR DESCRIPTION
## Contrast issue on markdown posts resolved

Explanation: Missing adaptation to the dark theme in prose class with the TailwndCSS typography plugin for rendering the component in the slug file (see following captures).

### Before :

![2024-03-08_16h18_52](https://github.com/C-Alexis4414/porfolio-alexis-chentre/assets/135022552/ec36f06c-f317-41aa-a2f1-5c096f9a629d)

Code in [...slug].vue

``` vue
<ContentRenderer :value="data" class="prose my-10 mx-auto max-w-7xl" />
```

### After :

![2024-03-08_16h19_23](https://github.com/C-Alexis4414/porfolio-alexis-chentre/assets/135022552/de7508db-ae89-45eb-b6e5-a66c541bd4d0)

``` vue
<ContentRenderer :value="data" class="prose dark:prose-invert my-10 mx-auto max-w-7xl" />
```